### PR TITLE
docs(flowlint-examples/R3): improve Set node config examples and clar…

### DIFF
--- a/R3/README.md
+++ b/R3/README.md
@@ -13,7 +13,8 @@
   - Yes → pass  
   - No → fail
 
-FlowLint only checks for presence of a candidate key in upstream node parameters. It doesn’t enforce storage strategy; that’s on your workflow (e.g., DB unique constraint, cache dedup).
+What this means: FlowLint only checks, že **na větvi k mutaci existuje a putuje idempotency klíč** (př. `eventId/messageId`). Skutečné zabránění duplicitám musí udělat cílový zápis (DB UNIQUE + UPSERT/`ON CONFLICT`, idempotency header na API, nebo dedup v cache).
+What this means: FlowLint only checks that an idempotency key (e.g., `eventId/messageId`) exists upstream and flows to the mutation. Preventing duplicates is done by the sink (DB UNIQUE + UPSERT/`ON CONFLICT`, idempotency header at the API, or cache-based dedup).
 
 ---
 
@@ -153,12 +154,15 @@ graph LR
    ```json
    {
      "parameters": {
+       "mode": "manual",
+       "keepOnlySet": true,
        "values": {
          "string": [
-           { "name": "eventId", "value": "={{ $json.event_id }}" }
+           { "name": "eventId", "value": "={{ $json.event_id || $json.eventId }}" }
          ]
-       }
-     }
+       },
+       "options": {}
+    }
    }
    ```
    → FlowLint detects `"eventId"` in Set node parameters ✅
@@ -206,12 +210,15 @@ graph LR
    ```json
    {
      "parameters": {
+       "mode": "manual",
+       "keepOnlySet": true,
        "values": {
          "string": [
-           { "name": "messageId", "value": "={{ $json.message_id }}" }
+           { "name": "messageId", "value": "={{ $json.message_id || $json.messageId }}" }
          ]
-       }
-     }
+       },
+       "options": {}
+    }
    }
    ```
    → FlowLint detects `"messageId"` in Set node parameters ✅

--- a/R3/good-example-with-eventId.json
+++ b/R3/good-example-with-eventId.json
@@ -14,12 +14,16 @@
       "id": "2",
       "type": "n8n-nodes-base.set",
       "name": "Capture eventId",
+      "typeVersion": 2,
       "parameters": {
+        "mode": "manual",
+        "keepOnlySet": true,
         "values": {
           "string": [
-            { "name": "eventId", "value": "={{ $json.event_id }}" }
+            { "name": "eventId", "value": "={{ $json.event_id || $json.eventId }}" }
           ]
-        }
+        },
+        "options": {}
       },
       "position": [250, 100]
     },

--- a/R3/good-example-with-messageId.json
+++ b/R3/good-example-with-messageId.json
@@ -14,12 +14,16 @@
       "id": "2",
       "type": "n8n-nodes-base.set",
       "name": "Capture messageId",
+      "typeVersion": 2,
       "parameters": {
+        "mode": "manual",
+        "keepOnlySet": true,
         "values": {
           "string": [
-            { "name": "messageId", "value": "={{ $json.message_id }}" }
+            { "name": "messageId", "value": "={{ $json.message_id || $json.messageId }}" }
           ]
-        }
+        },
+        "options": {}
       },
       "position": [250, 100]
     },


### PR DESCRIPTION
…ify FlowLint scope

  - Enhance "What this means" explanation with bilingual clarity
  - Add Set node config details: "mode": "manual", "keepOnlySet": true, "options": {}
  - Use fallback expressions in eventId/messageId: e.g., "{{ .event_id || .eventId }}"
  - Better guidance on FlowLint\'s role: detects key presence, but sink enforces idempotency