### PR TITLE
docs: R9 config literals rule examples

### DIFF
--- a/R9/README.md
+++ b/R9/README.md
@@ -1,0 +1,95 @@
+# R9: Config Literals (Environment-Specific Strings)
+
+## Overview
+
+**Rule:** R9 – Config Literals  
+**Severity:** `should`  
+**Purpose:** Prevent hardcoded environment URLs/names. Use expressions/credentials so workflows move safely between dev/stage/prod.
+
+**FlowLint check (how R9 detects warnings):**
+- Flags literal URLs with environment cues (`dev.`, `staging.`, `prod.`) or hardcoded env names (`production`, `staging`)
+- Looks at headers/query/body for inline config strings instead of `$env` / `$vars` / credentials
+- Encourages parameterization for portability
+
+**Why it matters:** Hardcoded envs cause accidental prod hits or broken deployments when moving workflows.
+
+---
+
+## 🔧 How to Fix R9 in n8n
+
+1. Move base URLs and env labels to **Environment variables** or **Credentials**.  
+2. Reference them via expressions:
+   - `={{ $env.API_BASE_URL }}`
+   - `={{ $vars.envName }}` or credentials parameters
+3. Avoid committing environment-specific literals.
+
+---
+
+## Example 1: ⚠️ BAD – Hardcoded Staging URL
+
+File: `bad-example.json`
+
+```mermaid
+%%{init: { "theme": "base", "themeVariables": { "primaryColor": "#38bdf8", "secondaryColor": "#fbbf24", "tertiaryColor": "#e2e8f0", "primaryTextColor": "#0f172a", "lineColor": "#94a3b8", "edgeLabelBackground": "#e2e8f0", "background": "transparent" } } }%%
+graph LR
+    A["🔔 Webhook"] --> B["🌐 Call API<br/>⚠️ https://api.staging.example.com"]
+
+    style A fill:#fff3cd
+    style B fill:#f8d7da
+```
+
+**FlowLint output:**
+```
+⚠️ R9 (should): Hardcoded env/config literal detected (staging URL).
+Use $env/$vars/credentials for base URLs.
+```
+
+---
+
+## Example 2: ✅ GOOD – Parameterized Base URL
+
+File: `good-example.json`
+
+```mermaid
+%%{init: { "theme": "base", "themeVariables": { "primaryColor": "#38bdf8", "secondaryColor": "#22c55e", "tertiaryColor": "#e2e8f0", "primaryTextColor": "#0f172a", "lineColor": "#94a3b8", "edgeLabelBackground": "#e2e8f0", "background": "transparent" } } }%%
+graph LR
+    A["🔔 Webhook"] --> B["🌐 Call API<br/>✅ baseUrl from $env.API_BASE_URL"]
+
+    style A fill:#d4edda
+    style B fill:#d4edda
+```
+
+**Why this passes:**
+- Base URL and env name come from expressions (`$env`, `$vars`)
+- No environment literals in the workflow JSON
+- Safe to promote between environments
+
+---
+
+## Configuration (`.flowlint.yml`)
+
+```yaml
+rules:
+  config_literals:
+    enabled: true
+    patterns:
+      - "(?i)staging"
+      - "(?i)production"
+      - "(?i)dev\\."
+```
+
+---
+
+## Test This Rule
+
+1) Import `bad-example.json`; FlowLint warns about hardcoded staging URL.  
+2) Import `good-example.json`; FlowLint passes.  
+3) CI: include both in a PR; expect one `should` annotation on the bad example.
+
+---
+
+## Related Rules
+
+- **R4** Secrets: keep credentials/config out of literals  
+- **R1** Rate Limit/Retry: still apply to API nodes  
+- **R10** Naming: use clear names for env-specific nodes when unavoidable  

--- a/R9/bad-example.json
+++ b/R9/bad-example.json
@@ -1,0 +1,53 @@
+{
+  "nodes": [
+    {
+      "id": "1",
+      "type": "n8n-nodes-base.webhook",
+      "name": "Webhook",
+      "parameters": {
+        "path": "config-literals-demo",
+        "httpMethod": "POST"
+      },
+      "position": [100, 100]
+    },
+    {
+      "id": "2",
+      "type": "n8n-nodes-base.httpRequest",
+      "name": "Call API (Staging Hardcoded)",
+      "parameters": {
+        "url": "https://api.staging.example.com/v1/leads",
+        "method": "POST",
+        "options": {},
+        "bodyParametersUi": {
+          "parameter": [
+            {
+              "name": "environment",
+              "value": "staging"
+            }
+          ]
+        }
+      },
+      "position": [360, 100]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Call API (Staging Hardcoded)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "description": "⚠️ BAD: Base URL and env name are hardcoded for staging. FlowLint R9 warns.",
+    "notes": [
+      "Hardcoded environment values break portability",
+      "Use $env or credentials for base URLs and environment labels"
+    ]
+  }
+}

--- a/R9/good-example.json
+++ b/R9/good-example.json
@@ -1,0 +1,83 @@
+{
+  "nodes": [
+    {
+      "id": "1",
+      "type": "n8n-nodes-base.webhook",
+      "name": "Webhook",
+      "parameters": {
+        "path": "config-literals-demo",
+        "httpMethod": "POST"
+      },
+      "position": [100, 100]
+    },
+    {
+      "id": "2",
+      "type": "n8n-nodes-base.set",
+      "name": "Set Environment Vars",
+      "typeVersion": 2,
+      "parameters": {
+        "mode": "manual",
+        "values": {
+          "string": [
+            {
+              "name": "envName",
+              "value": "={{ $env.ENV_NAME || 'dev' }}"
+            }
+          ]
+        }
+      },
+      "position": [260, 100]
+    },
+    {
+      "id": "3",
+      "type": "n8n-nodes-base.httpRequest",
+      "name": "Call API (Parametrized)",
+      "parameters": {
+        "url": "={{ $env.API_BASE_URL }}/v1/leads",
+        "method": "POST",
+        "options": {},
+        "bodyParametersUi": {
+          "parameter": [
+            {
+              "name": "environment",
+              "value": "={{ $json.envName }}"
+            }
+          ]
+        }
+      },
+      "position": [520, 100]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Set Environment Vars",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Environment Vars": {
+      "main": [
+        [
+          {
+            "node": "Call API (Parametrized)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "description": "✅ GOOD: Base URL and env name come from expressions ($env). No hardcoded environment literals; FlowLint R9 passes.",
+    "notes": [
+      "Portable across dev/stage/prod with different env vars",
+      "Safer deployment and review",
+      "Use credentials for auth tokens combined with env for base URLs"
+    ]
+  }
+}


### PR DESCRIPTION
Add standalone documentation branch with README, bad-example.json, and good-example.json for R9 rule (Config Literals - Environment-Specific Strings).