### PR TITLE
docs: R10 naming convention rule examples

### DIFF
--- a/R10/README.md
+++ b/R10/README.md
@@ -1,0 +1,96 @@
+# R10: Naming Convention (No Generic Node Names)
+
+## Overview
+
+**Rule:** R10 – Naming Convention  
+**Severity:** `nit`  
+**Purpose:** Prevent generic node names (e.g., "HTTP Request", "Set", "IF"). Names should describe intent so reviewers understand the flow quickly.
+
+**FlowLint check (how R10 detects warnings):**
+- Compares node names to a denylist of generic titles (configurable)
+- Flags names like `HTTP Request`, `Set`, `If`, `Function`, `Webhook`
+- Encourages intent-driven names (“Create Lead API”, “Filter VIPs”)
+
+**Why it matters:** Clear names speed up reviews, debugging, and handoffs.
+
+---
+
+## 🔧 How to Fix R10 in n8n
+
+1. Rename nodes to describe **what** they do and **why**.  
+2. Include target system or condition in the name (e.g., “Push to CRM”, “Filter Paid Plans”).  
+3. Keep names short but specific.
+
+---
+
+## Example 1: ⚠️ BAD – Generic Names
+
+File: `bad-example.json`
+
+```mermaid
+%%{init: { "theme": "base", "themeVariables": { "primaryColor": "#38bdf8", "secondaryColor": "#fbbf24", "tertiaryColor": "#e2e8f0", "primaryTextColor": "#0f172a", "lineColor": "#94a3b8", "edgeLabelBackground": "#e2e8f0", "background": "transparent" } } }%%
+graph LR
+    A["🔔 Webhook"] --> B["HTTP Request"] --> C["Set"]
+
+    style A fill:#fff3cd
+    style B fill:#f8d7da
+    style C fill:#f8d7da
+```
+
+**FlowLint output:**
+```
+⚠️ R10 (nit): Generic node names detected ("HTTP Request", "Set").
+Rename to reflect intent.
+```
+
+---
+
+## Example 2: ✅ GOOD – Intentful Names
+
+File: `good-example.json`
+
+```mermaid
+%%{init: { "theme": "base", "themeVariables": { "primaryColor": "#38bdf8", "secondaryColor": "#22c55e", "tertiaryColor": "#e2e8f0", "primaryTextColor": "#0f172a", "lineColor": "#94a3b8", "edgeLabelBackground": "#e2e8f0", "background": "transparent" } } }%%
+graph LR
+    A["🔔 Webhook"] --> B["🌐 Create Lead (CRM API)"] --> C["🧭 Map lead fields"]
+
+    style A fill:#d4edda
+    style B fill:#d4edda
+    style C fill:#d4edda
+```
+
+**Why this passes:**
+- Names show system and purpose (Create Lead, Map lead fields)
+- Easier review/debug; no generic labels
+
+---
+
+## Configuration (`.flowlint.yml`)
+
+```yaml
+rules:
+  naming_convention:
+    enabled: true
+    generic_names:
+      - "http request"
+      - "set"
+      - "if"
+      - "function"
+      - "webhook"
+```
+
+---
+
+## Test This Rule
+
+1) Import `bad-example.json`; FlowLint warns about generic names.  
+2) Import `good-example.json`; FlowLint passes.  
+3) CI: include both in a PR; expect one `nit` annotation on the bad example.
+
+---
+
+## Related Rules
+
+- **R4** Secrets: descriptive names help auditors spot secret use  
+- **R7** Alert/Log: name alert nodes with channels/owners  
+- **R5** Dead Ends: terminal nodes should be named intentionally (End/Stop)  

--- a/R10/bad-example.json
+++ b/R10/bad-example.json
@@ -1,0 +1,74 @@
+{
+  "nodes": [
+    {
+      "id": "1",
+      "type": "n8n-nodes-base.webhook",
+      "name": "Webhook",
+      "parameters": {
+        "path": "naming-demo",
+        "httpMethod": "POST"
+      },
+      "position": [100, 100]
+    },
+    {
+      "id": "2",
+      "type": "n8n-nodes-base.httpRequest",
+      "name": "HTTP Request",
+      "parameters": {
+        "url": "https://api.crm.example.com/leads",
+        "method": "POST",
+        "options": {}
+      },
+      "position": [320, 100]
+    },
+    {
+      "id": "3",
+      "type": "n8n-nodes-base.set",
+      "name": "Set",
+      "typeVersion": 2,
+      "parameters": {
+        "mode": "manual",
+        "values": {
+          "string": [
+            {
+              "name": "status",
+              "value": "new"
+            }
+          ]
+        }
+      },
+      "position": [520, 100]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "HTTP Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "HTTP Request": {
+      "main": [
+        [
+          {
+            "node": "Set",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "description": "⚠️ BAD: Generic node names ('HTTP Request', 'Set') reduce clarity. FlowLint R10 warns.",
+    "notes": [
+      "Rename nodes to show intent and target system",
+      "Helps reviewers and on-call debugging"
+    ]
+  }
+}

--- a/R10/good-example.json
+++ b/R10/good-example.json
@@ -1,0 +1,78 @@
+{
+  "nodes": [
+    {
+      "id": "1",
+      "type": "n8n-nodes-base.webhook",
+      "name": "Webhook",
+      "parameters": {
+        "path": "naming-demo",
+        "httpMethod": "POST"
+      },
+      "position": [100, 100]
+    },
+    {
+      "id": "2",
+      "type": "n8n-nodes-base.httpRequest",
+      "name": "Create Lead (CRM API)",
+      "parameters": {
+        "url": "https://api.crm.example.com/leads",
+        "method": "POST",
+        "options": {
+          "retry": {
+            "count": 3
+          }
+        }
+      },
+      "position": [320, 100]
+    },
+    {
+      "id": "3",
+      "type": "n8n-nodes-base.set",
+      "name": "Map lead fields",
+      "typeVersion": 2,
+      "parameters": {
+        "mode": "manual",
+        "values": {
+          "string": [
+            {
+              "name": "status",
+              "value": "qualified"
+            }
+          ]
+        }
+      },
+      "position": [520, 100]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Create Lead (CRM API)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Lead (CRM API)": {
+      "main": [
+        [
+          {
+            "node": "Map lead fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "description": "✅ GOOD: Intentful node names show system and purpose. FlowLint R10 passes.",
+    "notes": [
+      "Names communicate intent and target system",
+      "Retry on API node pairs with clarity"
+    ]
+  }
+}


### PR DESCRIPTION
Add standalone documentation branch with README, bad-example.json, and good-example.json for R10 rule (Naming Convention - No Generic Node Names).