### PR TITLE
docs: R11 deprecated nodes rule examples

### DIFF
--- a/R11/README.md
+++ b/R11/README.md
@@ -1,0 +1,93 @@
+# R11: Deprecated Nodes
+
+## Overview
+
+**Rule:** R11 – Deprecated Nodes  
+**Severity:** `should`  
+**Purpose:** Warn when workflows use node types marked as deprecated by your team/vendor so they can be migrated before removal.
+
+**FlowLint check (how R11 detects warnings):**
+- Compares node `type` against a configured deprecation list
+- Flags matches with a warning and suggests replacement
+- List is maintained in `.flowlint.yml` (per team)
+
+**Why it matters:** Deprecated nodes lose support, miss security fixes, and may break on upgrades.
+
+---
+
+## 🔧 How to Fix R11 in n8n
+
+1. Identify the replacement node (e.g., new API version or official integration).  
+2. Recreate the node with the supported type and migrate credentials/fields.  
+3. Remove the deprecated node from the flow.
+
+---
+
+## Example 1: ⚠️ BAD – Uses Deprecated HTTP (Legacy)
+
+File: `bad-example.json`
+
+```mermaid
+%%{init: { "theme": "base", "themeVariables": { "primaryColor": "#38bdf8", "secondaryColor": "#fbbf24", "tertiaryColor": "#e2e8f0", "primaryTextColor": "#0f172a", "lineColor": "#94a3b8", "edgeLabelBackground": "#e2e8f0", "background": "transparent" } } }%%
+graph LR
+    A["🔔 Webhook"] --> B["🌐 HTTP Request (Legacy)<br/>⚠️ deprecated type"]
+
+    style A fill:#fff3cd
+    style B fill:#f8d7da
+```
+
+**FlowLint output:**
+```
+⚠️ R11 (should): Node type n8n-nodes-base.httpRequest (legacy) is deprecated. Replace with HTTP Request (v2) or vendor node.
+```
+
+---
+
+## Example 2: ✅ GOOD – Migrated to Supported Node
+
+File: `good-example.json`
+
+```mermaid
+%%{init: { "theme": "base", "themeVariables": { "primaryColor": "#38bdf8", "secondaryColor": "#22c55e", "tertiaryColor": "#e2e8f0", "primaryTextColor": "#0f172a", "lineColor": "#94a3b8", "edgeLabelBackground": "#e2e8f0", "background": "transparent" } } }%%
+graph LR
+    A["🔔 Webhook"] --> B["🌐 HTTP Request (v2)<br/>✅ supported"]
+
+    style A fill:#d4edda
+    style B fill:#d4edda
+```
+
+**Why this passes:**
+- Uses the non-deprecated node type
+- Ready for platform upgrades and security fixes
+
+---
+
+## Configuration (`.flowlint.yml`)
+
+```yaml
+rules:
+  deprecated_nodes:
+    enabled: true
+    node_types:
+      - "n8n-nodes-base.httpRequest"      # legacy version
+      - "n8n-nodes-base.googleSheets"     # example; replace with official v2
+      - "n8n-nodes-base.emailSend"        # example; replace with SMTP/Email v2
+```
+
+> Adjust the list to match your team's deprecation policy and vendor guidance.
+
+---
+
+## Test This Rule
+
+1) Import `bad-example.json`; FlowLint warns about the deprecated node type.  
+2) Import `good-example.json`; FlowLint passes.  
+3) CI: include both in a PR; expect one `should` annotation on the bad example.
+
+---
+
+## Related Rules
+
+- **R4** Secrets: migrating may unlock better credential handling  
+- **R10** Naming: rename nodes to include target version during migration  
+- **R12** Unhandled Error Path: ensure the replacement still has error edges  

--- a/R11/bad-example.json
+++ b/R11/bad-example.json
@@ -1,0 +1,45 @@
+{
+  "nodes": [
+    {
+      "id": "1",
+      "type": "n8n-nodes-base.webhook",
+      "name": "Webhook",
+      "parameters": {
+        "path": "deprecated-demo",
+        "httpMethod": "POST"
+      },
+      "position": [100, 100]
+    },
+    {
+      "id": "2",
+      "type": "n8n-nodes-base.httpRequest",
+      "name": "HTTP Request (Legacy)",
+      "parameters": {
+        "url": "https://api.legacy.example.com/v1/data",
+        "method": "GET",
+        "options": {}
+      },
+      "position": [360, 100]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "HTTP Request (Legacy)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "description": "⚠️ BAD: Uses node type on the deprecated list (e.g., legacy HTTP Request). FlowLint R11 warns to migrate.",
+    "notes": [
+      "Replace with supported node (HTTP Request v2 or vendor-specific node)",
+      "Deprecated nodes may lose security fixes and break on upgrades"
+    ]
+  }
+}

--- a/R11/good-example.json
+++ b/R11/good-example.json
@@ -1,0 +1,49 @@
+{
+  "nodes": [
+    {
+      "id": "1",
+      "type": "n8n-nodes-base.webhook",
+      "name": "Webhook",
+      "parameters": {
+        "path": "deprecated-demo",
+        "httpMethod": "POST"
+      },
+      "position": [100, 100]
+    },
+    {
+      "id": "2",
+      "type": "n8n-nodes-base.httpRequestV2",
+      "name": "HTTP Request (v2)",
+      "parameters": {
+        "url": "https://api.new.example.com/v2/data",
+        "method": "GET",
+        "options": {
+          "retry": {
+            "count": 3
+          }
+        }
+      },
+      "position": [360, 100]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "HTTP Request (v2)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "description": "✅ GOOD: Uses supported node type (v2). FlowLint R11 passes.",
+    "notes": [
+      "Migrated away from deprecated node",
+      "Ready for platform upgrades and security fixes"
+    ]
+  }
+}


### PR DESCRIPTION
Add standalone documentation branch with README, bad-example.json, and good-example.json for R11 rule (Deprecated Nodes).